### PR TITLE
Add AutoUpdate

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,10 +152,8 @@ app.on('ready', function(){
   if (process.platform === 'darwin') {
     createMenu();
   }
-  // Disable MacOS update while app is not signed with Apple Dev Certificate
-  if (process.platform !== 'darwin') {
-    autoUpdater.checkForUpdates();
-  }
+  
+  autoUpdater.checkForUpdates();
 });
 
 //Full closure of the app
@@ -185,7 +183,11 @@ autoUpdater.on('update-available', function () {
     buttons: [i18n.__('Yes')+' ('+i18n.__('DownloadInBackground')+')', i18n.__('No')]
   }, (buttonIndex) => {
     if (buttonIndex === 0) {
-      autoUpdater.downloadUpdate()
+      if(process.platform === 'darwin') {
+        electron.shell.openExternal('https://github.com/Android-Messages-For-Desktop/android-messages-for-desktop/releases/latest');
+      } else {
+        autoUpdater.downloadUpdate()
+      }
     }
   })
 })

--- a/main.js
+++ b/main.js
@@ -3,12 +3,21 @@ const electron = require('electron');
 const path = require('path');
 const url = require('url');
 const windowStateKeeper = require('electron-window-state');
-const {app, BrowserWindow, Menu, MenuItem} = electron;
+const { app, BrowserWindow, Menu, MenuItem, dialog } = electron;
+const { autoUpdater } = require('electron-updater');
 
 let mainWindow
+let i18n
+
+let manualUpdate
+
+autoUpdater.autoDownload = false
 
 //Creating the window
 function createWindow () {
+
+  i18n = new(require('./translations/i18n'));
+  manualUpdate = false
 
   let mainWindowState = windowStateKeeper({
     defaultWidth: 1000,
@@ -62,8 +71,6 @@ function createWindow () {
 
 //Creating the menu
 function createMenu (){
-  var i18n = new(require('./translations/i18n'));
-
   const template = [
     {
     label: i18n.__('Edit'),
@@ -78,6 +85,13 @@ function createMenu (){
     {
       label: i18n.__('Window'),
       role: 'window'
+    },
+    {
+      label: '?',
+      submenu: [
+        {label: i18n.__('About'),role: 'about'},
+        {label: i18n.__('Update'), click: function click() { manualUpdate = true; autoUpdater.checkForUpdates(); }}
+      ]
     }
   ]
 
@@ -87,6 +101,7 @@ function createMenu (){
       label: name,
       submenu: [
         {label: i18n.__('About'),role: 'about'},
+        //{label: i18n.__('Update'), click: function click() { manualUpdate = true; autoUpdater.checkForUpdates(); }},
         {type: 'separator'},
         {label: i18n.__('Disconnect account'), click: function click() {clearAppCache(); }},
         {type: 'separator'},
@@ -137,6 +152,10 @@ app.on('ready', function(){
   if (process.platform === 'darwin') {
     createMenu();
   }
+  // Disable MacOS update while app is not signed with Apple Dev Certificate
+  if (process.platform !== 'darwin') {
+    autoUpdater.checkForUpdates();
+  }
 });
 
 //Full closure of the app
@@ -151,4 +170,40 @@ app.on('activate', function () {
   if (mainWindow === null) {
     createWindow()
   }
+})
+
+/// Auto Updater
+autoUpdater.on('error', function (error) {
+  dialog.showErrorBox('Error: ', error == null ? "unknown" : (error.stack || error).toString())
+})
+
+autoUpdater.on('update-available', function () {
+  dialog.showMessageBox({
+    type: 'info',
+    title: i18n.__('FoundUpdate'),
+    message: i18n.__('UpdateFounded'),
+    buttons: [i18n.__('Yes')+' ('+i18n.__('DownloadInBackground')+')', i18n.__('No')]
+  }, (buttonIndex) => {
+    if (buttonIndex === 0) {
+      autoUpdater.downloadUpdate()
+    }
+  })
+})
+
+autoUpdater.on('update-not-available', function () {
+  if(manualUpdate === true) {
+    dialog.showMessageBox({
+      title: i18n.__('NoUpdate'),
+      message: i18n.__('NoUpdateAvailable')
+    })
+  }
+})
+
+autoUpdater.on('update-downloaded', function () {
+  dialog.showMessageBox({
+    title: i18n.__('Update'),
+    message: i18n.__('UpdateDownloaded')
+  }, function () {
+    setImmediate(() => autoUpdater.quitAndInstall())
+  })
 })

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "electron-context-menu": "^0.10.0",
+    "electron-updater": "^4.0.6",
     "electron-window-state": "^4.1.1",
     "i18n": "^0.8.3"
   }

--- a/translations/de.js
+++ b/translations/de.js
@@ -14,5 +14,15 @@
  "Hide": "Ausblenden",
  "Hide others": "Andere ausblenden",
  "Unhide": "Alle einblenden",
- "Quit": "Beenden"
+ "Quit": "Beenden",
+ "Update": "Update",
+ "FoundUpdate": "Searching update",
+ "UpdateFounded": "Update founded, do you want to download it ?",
+ "Yes": "Yes",
+ "No": "No",
+ "DownloadInBackground": "Download in background",
+ "NoUpdate": "No update available",
+ "NoUpdateAvailable": "Current version is up-to-date",
+ "Downloading": "Downloading ...",
+ "UpdateDownloaded": "Updates downloaded, application will be quit for update..."
 }

--- a/translations/en.js
+++ b/translations/en.js
@@ -14,5 +14,15 @@
  "Hide": "Hide",
  "Hide others": "Hide others",
  "Unhide": "Unhide",
- "Quit": "Quit"
+ "Quit": "Quit",
+ "Update": "Update",
+ "FoundUpdate": "Searching update",
+ "UpdateFounded": "Update founded, do you want to download it ?",
+ "Yes": "Yes",
+ "No": "No",
+ "DownloadInBackground": "Download in background",
+ "NoUpdate": "No update available",
+ "NoUpdateAvailable": "Current version is up-to-date",
+ "Downloading": "Downloading ...",
+ "UpdateDownloaded": "Updates downloaded, application will be quit for update..."
 }

--- a/translations/fr.js
+++ b/translations/fr.js
@@ -14,5 +14,15 @@
  "Hide": "Masquer",
  "Hide others": "Masquer les autres",
  "Unhide": "Tout afficher",
- "Quit": "Quitter"
+ "Quit": "Quitter",
+ "Update": "Mise à jour",
+ "FoundUpdate": "Recherche de mise à jour",
+ "UpdateFounded": "Mise à jour disponible, voulez-vous la télécharger ?",
+ "Yes": "Oui",
+ "No": "Non",
+ "DownloadInBackground": "Téléchargement en fond",
+ "NoUpdate": "Aucune mise à jour",
+ "NoUpdateAvailable": "La version actuelle est la plus récente",
+ "Downloading": "Téléchargement en cours ...",
+ "UpdateDownloaded": "Mise à jour télécharger, l'application va se fermer durant la mise à jour..."
 }


### PR DESCRIPTION
Add autoupdate for Windows and Linux(not tested)
Extend default menu (Windows and Linux) but not display

De translation not done (I don't speak it)

MacOS update disable (no Dev Certificate to sign app and test it).
If you want to enable it, you have to remove the following line in your package.json
`
"target": "dmg"
`